### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -30,7 +30,7 @@
     <repository>
       <id>camunda-bpm-nexus</id>
       <name>camunda-bpm-nexus</name>
-      <url>https://app.camunda.com/nexus/content/groups/public</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 

--- a/maven-plugin/src/test/it/advanced-multi-instance/pom.xml
+++ b/maven-plugin/src/test/it/advanced-multi-instance/pom.xml
@@ -22,7 +22,7 @@
     <repository>
       <id>camunda-bpm-nexus</id>
       <name>camunda-bpm-nexus</name>
-      <url>https://app.camunda.com/nexus/content/groups/public</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 

--- a/maven-plugin/src/test/it/advanced-spring/pom.xml
+++ b/maven-plugin/src/test/it/advanced-spring/pom.xml
@@ -23,7 +23,7 @@
     <repository>
       <id>camunda-bpm-nexus</id>
       <name>camunda-bpm-nexus</name>
-      <url>https://app.camunda.com/nexus/content/groups/public</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 

--- a/maven-plugin/src/test/it/advanced/pom.xml
+++ b/maven-plugin/src/test/it/advanced/pom.xml
@@ -22,7 +22,7 @@
     <repository>
       <id>camunda-bpm-nexus</id>
       <name>camunda-bpm-nexus</name>
-      <url>https://app.camunda.com/nexus/content/groups/public</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 

--- a/maven-plugin/src/test/it/simple/pom.xml
+++ b/maven-plugin/src/test/it/simple/pom.xml
@@ -22,7 +22,7 @@
     <repository>
       <id>camunda-bpm-nexus</id>
       <name>camunda-bpm-nexus</name>
-      <url>https://app.camunda.com/nexus/content/groups/public</url>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
We created a new domain name for our repository manager (Artifactory) to replace the old Nexus proxy URL (app.camunda.com/nexus). The proxy URL will be removed in the future. 

Related to INFRA-3114



