### PR TITLE
fix: disabled plugin menu action when tab type is cloud-bpmn

### DIFF
--- a/camunda-modeler-plugin/menu.js
+++ b/camunda-modeler-plugin/menu.js
@@ -5,7 +5,9 @@ module.exports = function(electronApp, menuState) {
     label: "Show / Hide",
     accelerator: "CommandOrControl+T",
     enabled: function() {
-      return menuState.bpmn;
+      // enable menu action for tab type "bpmn", but not for "cloud-bpmn"
+      // property "activeTab" is available since Camunda Modeler 5.9.0
+      return menuState.bpmn && (menuState.activeTab === undefined || menuState.activeTab.type === "bpmn");
     },
     action: function() {
       electronApp.emit("menu:action", "toggleBpmnDrivenTesting");


### PR DESCRIPTION
Closes #114